### PR TITLE
More test from mirage-tcpip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,12 @@ script: bash -ex .travis-opam.sh
 sudo: required
 env:
   global:
-    - PACKAGE="arp"
-    - DEPOPTS="arp-mirage"
     - PINS="arp.1.0.0:. arp-mirage.1.0.0:."
     - TESTS=true
   matrix:
-    - OCAML_VERSION=4.04
-    - OCAML_VERSION=4.05
-    - OCAML_VERSION=4.06
-    - OCAML_VERSION=4.07
+    - OCAML_VERSION=4.04 PACKAGE="arp-mirage"
+    - OCAML_VERSION=4.05 PACKAGE="arp"
+    - OCAML_VERSION=4.06 PACKAGE="arp-mirage"
+    - OCAML_VERSION=4.07 PACKAGE="arp"
 notifications:
   email: false

--- a/arp-mirage.opam
+++ b/arp-mirage.opam
@@ -11,13 +11,20 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "mirage-protocols-lwt"
   "mirage-time-lwt"
-  "mirage-clock"
-  "mirage-protocols"
+  "mirage-protocols-lwt"
   "tcpip" {>="2.8.0"}
   "lwt"
   "duration"
   "arp" {>= "1.0.0"}
+  "logs"
+  "cstruct" {>= "2.2.0"}
+  "fmt" {with-test}
   "mirage-vnetif" {with-test}
+  "alcotest" {with-test}
+  "mirage-clock-unix" {with-test}
+  "mirage-random" {with-test}
+  "mirage-random-test" {with-test}
+  "mirage-unix" {with-test}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -74,7 +74,7 @@ open Lwt.Infix
 module B = Basic_backend.Make
 module V = Vnetif.Make(B)
 module E = Ethif.Make(V)
-module A = Arp.Make(E)(Mclock)(OS.Time)
+module A = Arp.Make(E)(OS.Time)
 
 let c = ref 0
 let gen arp () =
@@ -112,8 +112,7 @@ let get_arp ?(backend = B.create ~use_async_readers:true
                 ~yield:(fun() -> Lwt_main.yield ()) ()) () =
   V.connect backend >>= fun netif ->
   E.connect netif >>= fun ethif ->
-  Mclock.connect () >>= fun mclock ->
-  A.connect ethif mclock >>= fun arp ->
+  A.connect ethif >>= fun arp ->
   Lwt.return { backend; netif; ethif; arp }
 
 let rec send netif gen () =

--- a/bench/dune
+++ b/bench/dune
@@ -1,6 +1,6 @@
 (executable
  (name bench)
- (libraries arp-mirage mirage-vnetif lwt ipaddr tcpip.ethif mirage-unix mirage-clock-unix mirage-types mirage-random mirage-random-test lwt.unix))
+ (libraries arp-mirage mirage-vnetif lwt ipaddr tcpip.ethif mirage-unix mirage-clock-unix mirage-random mirage-random-test lwt.unix))
 
 (alias
  (name runbench)

--- a/mirage/arp.mli
+++ b/mirage/arp.mli
@@ -15,8 +15,8 @@
  *
  *)
 
-module Make (Ethif : Mirage_protocols_lwt.ETHIF) (Clock : Mirage_clock.MCLOCK) (Time : Mirage_time_lwt.S) : sig
+module Make (Ethif : Mirage_protocols_lwt.ETHIF) (Time : Mirage_time_lwt.S) : sig
   include Mirage_protocols_lwt.ARP
 
-  val connect : Ethif.t -> Clock.t -> t Lwt.t
+  val connect : Ethif.t -> t Lwt.t
 end

--- a/mirage/dune
+++ b/mirage/dune
@@ -2,4 +2,4 @@
  (name arp_mirage)
  (public_name arp-mirage)
  (wrapped false)
- (libraries arp mirage-protocols mirage-protocols-lwt mirage-clock mirage-time-lwt lwt logs tcpip.ethif duration))
+ (libraries arp mirage-protocols mirage-protocols-lwt mirage-time-lwt lwt logs tcpip.ethif duration))

--- a/src/arp_handler.ml
+++ b/src/arp_handler.ml
@@ -16,7 +16,13 @@ type 'a t = {
   logsrc : Logs.src
 }
 
-let ip t = t.ip
+let ips t =
+  M.fold (fun ip entry acc -> match entry with
+      | Static (_, true) -> ip :: acc
+      | _ -> acc)
+    t.cache []
+
+let mac t = t.mac
 
 (*BISECT-IGNORE-BEGIN*)
 let pp_entry now k pp =

--- a/src/arp_handler.mli
+++ b/src/arp_handler.mli
@@ -63,8 +63,11 @@ val pp : Format.formatter -> 'a t -> unit
 
 (** {2 Predicates} *)
 
-(** [ip t] is [ip], the configured IPv4 address. *)
-val ip : 'a t -> Ipaddr.V4.t
+(** [ips t] is [ips], the advertised IPv4 addresses. *)
+val ips : 'a t -> Ipaddr.V4.t list
+
+(** [mac t] is [mac], the mac address used by the ARP handler. *)
+val mac : 'a t -> Macaddr.t
 
 (** [in_cache t ip] is [mac option], a MAC address if the ARP cache contains an
     entry, [None] otherwise. *)

--- a/src/arp_packet.ml
+++ b/src/arp_packet.ml
@@ -27,6 +27,13 @@ type t = {
   target_ip : Ipaddr.V4.t;
 }
 
+let equal a b =
+  op_to_int a.operation = op_to_int b.operation &&
+  Macaddr.compare a.source_mac b.source_mac = 0 &&
+  Ipaddr.V4.compare a.source_ip b.source_ip = 0 &&
+  Macaddr.compare a.target_mac b.target_mac = 0 &&
+  Ipaddr.V4.compare a.target_ip b.target_ip = 0
+
 type error =
   | Too_short
   | Unusable
@@ -35,10 +42,12 @@ type error =
 (*BISECT-IGNORE-BEGIN*)
 let pp fmt t =
   if t.operation = Request then
-    Format.fprintf fmt "ARP request, who has %a tell %a"
+    Format.fprintf fmt "ARP request from %a to %a, who has %a tell %a"
+      Macaddr.pp t.source_mac Macaddr.pp t.target_mac
       Ipaddr.V4.pp t.target_ip Ipaddr.V4.pp t.source_ip
   else (* t.op = Reply *)
-    Format.fprintf fmt "ARP reply, %a is at %a"
+    Format.fprintf fmt "ARP reply from %a to %a, %a is at %a"
+      Macaddr.pp t.source_mac Macaddr.pp t.target_mac
       Ipaddr.V4.pp t.source_ip Macaddr.pp t.source_mac
 
 let pp_error ppf = function

--- a/src/arp_packet.mli
+++ b/src/arp_packet.mli
@@ -24,6 +24,9 @@ type t = {
 (** [pp ppf t] prints the frame [t] on [ppf]. *)
 val pp : Format.formatter -> t -> unit
 
+(** [equal a b] returns [true] if frames [a] and [b] are equal, [false] otherwise. *)
+val equal : t -> t -> bool
+
 (** The type of possible errors during decoding
 
     - [Too_short] if the provided buffer is not long enough

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,4 @@
 (test
  (name tests)
- (libraries arp mirage-random mirage-random-test alcotest))
+ (package arp)
+ (libraries arp mirage-random mirage-random-test macaddr cstruct alcotest))

--- a/test/mirage/dune
+++ b/test/mirage/dune
@@ -1,0 +1,5 @@
+(test
+  (name tests)
+  (package arp-mirage)
+  (libraries alcotest lwt.unix logs logs.fmt fmt mirage-flow mirage-vnetif
+             mirage-clock-unix duration tcpip.ethif arp arp-mirage cstruct))

--- a/test/mirage/tests.ml
+++ b/test/mirage/tests.ml
@@ -1,0 +1,533 @@
+open Lwt.Infix
+
+let time_reduction_factor = 600
+
+module Time = struct
+  type 'a io = 'a Lwt.t
+  let sleep_ns ns = Lwt_unix.sleep (Duration.to_f ns)
+end
+module Fast_time = struct
+  type 'a io = 'a Lwt.t
+  let sleep_ns time = Time.sleep_ns Int64.(div time (of_int time_reduction_factor))
+end
+
+module B = Basic_backend.Make
+module V = Vnetif.Make(B)
+module E = Ethif.Make(V)
+module A = Arp.Make(E)(Fast_time)
+
+let src = Logs.Src.create "test_arp" ~doc:"Mirage ARP tester"
+module Log = (val Logs.src_log src : Logs.LOG)
+
+type arp_stack = {
+  backend : B.t;
+  netif: V.t;
+  ethif: E.t;
+  arp: A.t;
+}
+
+let first_ip = Ipaddr.V4.of_string_exn "192.168.3.1"
+let second_ip = Ipaddr.V4.of_string_exn "192.168.3.10"
+let sample_mac = Macaddr.of_string_exn "10:9a:dd:c0:ff:ee"
+
+let packet = (module Arp_packet : Alcotest.TESTABLE with type t = Arp_packet.t)
+let ip =
+  let module M = struct
+    type t = Ipaddr.V4.t
+    let pp = Ipaddr.V4.pp
+    let equal p q = (Ipaddr.V4.compare p q) = 0
+  end in
+  (module M : Alcotest.TESTABLE with type t = M.t)
+
+let macaddr =
+  let module M = struct
+    type t = Macaddr.t
+    let pp = Macaddr.pp
+    let equal p q = (Macaddr.compare p q) = 0
+  end in
+  (module M : Alcotest.TESTABLE with type t = M.t)
+
+let check_header ~message expected actual =
+  Alcotest.(check packet) message expected actual
+
+let fail = Alcotest.fail
+let failf fmt = Fmt.kstrf Alcotest.fail fmt
+
+let timeout ~time t =
+  let msg = Printf.sprintf "Timed out: didn't complete in %d milliseconds" time in
+  Lwt.pick [ t; Time.sleep_ns (Duration.of_ms time) >>= fun () -> fail msg; ]
+
+let check_response expected buf =
+  match Arp_packet.decode buf with
+  | Error s -> Alcotest.fail (Fmt.to_to_string Arp_packet.pp_error s)
+  | Ok actual ->
+    Alcotest.(check packet) "parsed packet comparison" expected actual
+
+let check_ethif_response expected buf =
+  let open Ethif_packet in
+  match Unmarshal.of_cstruct buf with
+  | Error s -> Alcotest.fail s
+  | Ok ({ethertype; _}, arp) ->
+    match ethertype with
+    | Ethif_wire.ARP -> check_response expected arp
+    | _ -> Alcotest.fail "Ethernet packet with non-ARP ethertype"
+
+let garp source_mac source_ip =
+  let open Arp_packet in
+  {
+    operation = Request;
+    source_mac;
+    target_mac = Macaddr.of_bytes_exn "\000\000\000\000\000\000";
+    source_ip;
+    target_ip = source_ip;
+  }
+
+let fail_on_receipt netif buf =
+  Alcotest.fail (Format.asprintf "received traffic when none was expected on interface %a: %a"
+	  Macaddr.pp (V.mac netif) Cstruct.hexdump_pp buf)
+
+let single_check netif expected =
+  V.listen netif (fun buf ->
+      match Ethif_packet.Unmarshal.of_cstruct buf with
+      | Error _ -> failwith "sad face"
+      | Ok (_, payload) ->
+        check_response expected payload; V.disconnect netif) >|= fun _ -> ()
+
+let wrap_arp arp =
+  let open Arp_packet in
+  let e =
+    { Ethif_packet.source = arp.source_mac;
+      destination = arp.target_mac;
+      ethertype = Ethif_wire.ARP;
+    } in
+  let p = Ethif_packet.Marshal.make_cstruct e in
+  Format.printf "%a" Ethif_packet.pp e;
+  Cstruct.hexdump p;
+  p
+
+let arp_reply ~from_netif ~to_netif ~from_ip ~to_ip =
+  let open Arp_packet in
+  let a =
+    { operation = Reply;
+      source_mac = (V.mac from_netif);
+      target_mac = (V.mac to_netif);
+      source_ip = from_ip;
+      target_ip = to_ip}
+  in
+  Cstruct.concat [wrap_arp a; encode a]
+
+let arp_request ~from_netif ~to_mac ~from_ip ~to_ip =
+  let open Arp_packet in
+  let a =
+    { operation = Request;
+      source_mac = (V.mac from_netif);
+      target_mac = to_mac;
+      source_ip = from_ip;
+      target_ip = to_ip}
+  in
+  Cstruct.concat [wrap_arp a; encode a]
+
+let get_arp ?backend () =
+  let backend = match backend with
+    | None -> B.create ~use_async_readers:true ~yield:Lwt_main.yield ()
+    | Some b -> b
+  in
+  V.connect backend >>= fun netif ->
+  E.connect netif >>= fun ethif ->
+  A.connect ethif >>= fun arp ->
+  Lwt.return { backend; netif; ethif; arp }
+
+(* we almost always want two stacks on the same backend *)
+let two_arp () =
+  get_arp () >>= fun first ->
+  get_arp ~backend:first.backend () >>= fun second ->
+  Lwt.return (first, second)
+
+(* ...but sometimes we want three *)
+let three_arp () =
+  get_arp () >>= fun first ->
+  get_arp ~backend:first.backend () >>= fun second ->
+  get_arp ~backend:first.backend () >>= fun third ->
+  Lwt.return (first, second, third)
+
+let query_or_die arp ip expected_mac =
+  A.query arp ip >>= function
+  | Error `Timeout ->
+    A.to_repr arp >>= fun repr ->
+    Log.warn (fun f -> f "Timeout querying %a. Table contents: %a"
+                 Ipaddr.V4.pp ip A.pp repr);
+    fail "ARP query failed when success was mandatory";
+  | Ok mac ->
+    Alcotest.(check macaddr) "mismatch for expected query value" expected_mac mac;
+    Lwt.return_unit
+  | Error e -> failf "ARP query failed with %a" A.pp_error e
+
+let query_and_no_response arp ip =
+  A.query arp ip >>= function
+  | Error `Timeout ->
+    A.to_repr arp >>= fun repr ->
+    Log.warn (fun f -> f "Timeout querying %a. Table contents: %a" Ipaddr.V4.pp ip A.pp repr);
+    Lwt.return_unit
+  | Ok _ -> failf "expected nothing, found something in cache"
+  | Error e ->
+    Log.err (fun m -> m "another err");
+    failf "ARP query failed with %a" A.pp_error e
+
+let set_and_check ~listener ~claimant ip =
+  A.set_ips claimant.arp [ ip ] >>= fun () ->
+  Log.debug (fun f -> f "Set IP for %a to %a" Macaddr.pp (V.mac claimant.netif) Ipaddr.V4.pp ip);
+  A.to_repr listener >>= fun repr ->
+  Logs.debug (fun f -> f "Listener table contents after IP set on claimant: %a" A.pp repr);
+  query_or_die listener ip (V.mac claimant.netif)
+
+let start_arp_listener stack () =
+  let noop = (fun _ -> Lwt.return_unit) in
+  Log.debug (fun f -> f "starting arp listener for %a" Macaddr.pp (V.mac stack.netif));
+  let arpv4 frame =
+    Log.debug (fun f -> f "frame received for arpv4");
+    A.input stack.arp frame
+  in
+  E.input ~arpv4 ~ipv4:noop ~ipv6:noop stack.ethif
+
+let output_then_disconnect ~speak:speak_netif ~disconnect:listen_netif bufs =
+  Lwt.join (List.map (fun b -> V.write speak_netif b >|= fun _ -> ()) bufs) >>= fun () ->
+  Lwt_unix.sleep 0.1 >>= fun () ->
+  V.disconnect listen_netif
+
+let not_in_cache ~listen probe arp ip =
+  Lwt.pick [
+    single_check listen probe;
+    Time.sleep_ns (Duration.of_ms 100) >>= fun () ->
+    A.query arp ip >>= function
+    | Ok _ -> failf "entry in cache when it shouldn't be %a" Ipaddr.V4.pp ip
+    | Error `Timeout -> Lwt.return_unit
+    | Error e -> failf "error for %a while reading the cache: %a"
+                   Ipaddr.V4.pp ip A.pp_error e
+  ]
+
+let set_ip_sends_garp () =
+  two_arp () >>= fun (speak, listen) ->
+  let emit_garp =
+    Time.sleep_ns (Duration.of_ms 100) >>= fun () ->
+    A.set_ips speak.arp [ first_ip ] >>= fun () ->
+    Alcotest.(check (list ip)) "garp emitted when setting ip" [ first_ip ] (A.get_ips speak.arp);
+    Lwt.return_unit
+  in
+  let expected_garp = garp (V.mac speak.netif) first_ip in
+  timeout ~time:500 (
+  Lwt.join [
+    single_check listen.netif expected_garp;
+    emit_garp;
+  ]) >>= fun () ->
+  (* now make sure we have consistency when setting *)
+  A.set_ips speak.arp [] >>= fun () ->
+  Alcotest.(check (slist ip Ipaddr.V4.compare)) "list of bound IPs on initialization" [] (A.get_ips speak.arp);
+  A.set_ips speak.arp [ first_ip; second_ip ] >>= fun () ->
+  Alcotest.(check (slist ip Ipaddr.V4.compare)) "list of bound IPs after setting two IPs"
+    [ first_ip; second_ip ] (A.get_ips speak.arp);
+  Lwt.return_unit
+
+let add_get_remove_ips () =
+  get_arp () >>= fun stack ->
+  let check str expected =
+    Alcotest.(check (list ip)) str expected (A.get_ips stack.arp)
+  in
+  check "bound ips is an empty list on startup" [];
+  A.set_ips stack.arp [ first_ip; first_ip ] >>= fun () ->
+  check "set ips with duplicate elements result in deduplication" [first_ip];
+  A.remove_ip stack.arp first_ip >>= fun () ->
+  check "ip list is empty after removing only ip" [];
+  A.remove_ip stack.arp first_ip >>= fun () ->
+  check "ip list is empty after removing from empty list" [];
+  A.add_ip stack.arp first_ip >>= fun () ->
+  check "first ip is the only member of the set of bound ips" [first_ip];
+  A.add_ip stack.arp first_ip >>= fun () ->
+  check "adding ips is idempotent" [first_ip];
+  Lwt.return_unit
+
+let input_single_garp () =
+  two_arp () >>= fun (listen, speak) ->
+  (* set the IP on speak_arp, which should cause a GARP to be emitted which
+     listen_arp will hear and cache. *)
+  let one_and_done buf =
+    let arpbuf = Cstruct.shift buf 14 in
+    A.input listen.arp arpbuf >>= fun () ->
+    V.disconnect listen.netif
+  in
+  timeout ~time:500 (
+    Lwt.join [
+      (V.listen listen.netif one_and_done >|= fun _ -> ());
+      Time.sleep_ns (Duration.of_ms 100) >>= fun () ->
+      Lwt.async (fun () -> A.query listen.arp first_ip >|= ignore) ;
+      A.set_ips speak.arp [ first_ip ];
+    ])
+    >>= fun () ->
+  (* try a lookup of the IP set by speak.arp, and fail if this causes listen_arp
+     to block or send an ARP query -- listen_arp should answer immediately from
+     the cache.  An attempt to resolve via query will result in a timeout, since
+     speak.arp has no listener running and therefore won't answer any arp
+     who-has requests. *)
+    timeout ~time:500 (query_or_die listen.arp first_ip (V.mac speak.netif)) (* >>= fun () ->
+                                                                                Time.sleep_ns (Duration.of_sec 5) *)
+
+let input_single_unicast () =
+  two_arp () >>= fun (listen, speak) ->
+  (* contrive to make a reply packet for the listener to hear *)
+  let for_listener = arp_reply
+     ~from_netif:speak.netif ~to_netif:listen.netif ~from_ip:first_ip ~to_ip:second_ip
+  in
+  let listener = start_arp_listener listen () in
+  timeout ~time:500 (
+  Lwt.choose [
+    (V.listen listen.netif listener >|= fun _ -> ());
+    Time.sleep_ns (Duration.of_ms 2) >>= fun () ->
+    V.write speak.netif for_listener >>= fun _ ->
+    query_and_no_response listen.arp first_ip
+  ])
+
+let input_resolves_wait () =
+  two_arp () >>= fun (listen, speak) ->
+  (* contrive to make a reply packet for the listener to hear *)
+  let for_listener = arp_reply ~from_netif:speak.netif ~to_netif:listen.netif
+                         ~from_ip:first_ip ~to_ip:second_ip in
+  (* initiate query when the cache is empty.  On resolution, fail for a timeout
+     and test the MAC if resolution was successful, then disconnect the
+     listening interface to ensure the test terminates.
+     Fail with a timeout message if the whole thing takes more than 5s. *)
+  let listener = start_arp_listener listen () in
+  let query_then_disconnect =
+    query_or_die listen.arp first_ip (V.mac speak.netif) >>= fun () ->
+    V.disconnect listen.netif
+  in
+  timeout ~time:5000 (
+    Lwt.join [
+      (V.listen listen.netif listener >|= fun _ -> ());
+      query_then_disconnect;
+      Time.sleep_ns (Duration.of_ms 1) >>= fun () ->
+      E.write speak.ethif for_listener >|= function
+      | Ok x -> x
+      | Error _ -> failf "ethernet write failed"
+    ]
+  )
+
+let unreachable_times_out () =
+  get_arp () >>= fun speak ->
+  A.query speak.arp first_ip >>= function
+  | Ok _ -> failf "query claimed success when impossible for %a" Ipaddr.V4.pp first_ip
+  | Error `Timeout -> Lwt.return_unit
+  | Error e -> failf "error waiting for a timeout: %a" A.pp_error e
+
+let input_replaces_old () =
+  three_arp () >>= fun (listen, claimant_1, claimant_2) ->
+  (* query for IP to accept responses *)
+  Lwt.async (fun () -> A.query listen.arp first_ip >|= ignore) ;
+  Lwt.async (fun () ->
+      Log.debug (fun f -> f "arp listener started");
+      V.listen listen.netif (start_arp_listener listen ()));
+  timeout ~time:2000 (
+    set_and_check ~listener:listen.arp ~claimant:claimant_1 first_ip >>= fun () ->
+    set_and_check ~listener:listen.arp ~claimant:claimant_2 first_ip >>= fun () ->
+    V.disconnect listen.netif
+    )
+
+let entries_expire () =
+  two_arp () >>= fun (listen, speak) ->
+  A.set_ips listen.arp [ second_ip ] >>= fun () ->
+  (* here's what we expect listener to emit once its cache entry has expired *)
+  let expected_arp_query =
+    Arp_packet.({operation = Request;
+                 source_mac = (V.mac listen.netif);
+                 target_mac = Macaddr.broadcast;
+                 source_ip = second_ip; target_ip = first_ip})
+  in
+  (* query for IP to accept responses *)
+  Lwt.async (fun () -> A.query listen.arp first_ip >|= ignore) ;
+  Lwt.async (fun () -> V.listen listen.netif (start_arp_listener listen ()));
+  let test =
+    Time.sleep_ns (Duration.of_ms 10) >>= fun () ->
+    set_and_check ~listener:listen.arp ~claimant:speak first_ip >>= fun () ->
+    (* sleep for 3s to make sure we hit `tick` often enough *)
+    Time.sleep_ns (Duration.of_sec 3) >>= fun () ->
+    (* asking now should generate a query *)
+    not_in_cache ~listen:speak.netif expected_arp_query listen.arp first_ip
+  in
+  timeout ~time:5000 test
+
+(* RFC isn't strict on how many times to try, so we'll just say any number
+   greater than 1 is fine *)
+let query_retries () =
+  two_arp () >>= fun (listen, speak) ->
+  let expected_query = Arp_packet.({source_mac = (V.mac speak.netif);
+                                    target_mac = Macaddr.broadcast;
+                                    source_ip = Ipaddr.V4.any;
+                                    target_ip = first_ip;
+                                    operation = Request;})
+  in
+  let how_many = ref 0 in
+  let listener buf =
+    check_ethif_response expected_query buf;
+    if !how_many = 0 then begin
+      how_many := !how_many + 1;
+      Lwt.return_unit
+    end else V.disconnect listen.netif
+  in
+  let ask () =
+    A.query speak.arp first_ip >>= function
+    | Error e -> failf "Received error before >1 query: %a" A.pp_error e
+    | Ok _ -> failf "got result from query for %a, erroneously" Ipaddr.V4.pp first_ip
+  in
+  Lwt.pick [
+    (V.listen listen.netif listener >|= fun _ -> ());
+    Time.sleep_ns (Duration.of_ms 2) >>= ask;
+    Time.sleep_ns (Duration.of_sec 6) >>= fun () ->
+    fail "query didn't succeed or fail within 6s"
+  ]
+
+(* requests for us elicit a reply *)
+let requests_are_responded_to () =
+  let (answerer_ip, inquirer_ip) = (first_ip, second_ip) in
+  two_arp () >>= fun (inquirer, answerer) ->
+  (* neither has a listener set up when we set IPs, so no GARPs in the cache *)
+  A.add_ip answerer.arp answerer_ip >>= fun () ->
+  A.add_ip inquirer.arp inquirer_ip >>= fun () ->
+  let request = arp_request ~from_netif:inquirer.netif ~to_mac:Macaddr.broadcast
+      ~from_ip:inquirer_ip ~to_ip:answerer_ip
+  in
+  let expected_reply =
+    Arp_packet.({ operation = Reply;
+                  source_mac = (V.mac answerer.netif);
+                  target_mac = (V.mac inquirer.netif);
+                  source_ip = answerer_ip; target_ip = inquirer_ip})
+  in
+  let listener close_netif buf =
+    check_ethif_response expected_reply buf;
+    V.disconnect close_netif
+  in
+  let arp_listener =
+    V.listen answerer.netif (start_arp_listener answerer ()) >|= fun _ -> ()
+  in
+  timeout ~time:1000 (
+    Lwt.join [
+      (* listen for responses and check them against an expected result *)
+      (V.listen inquirer.netif (listener inquirer.netif) >|= fun _ -> ());
+      (* start the usual ARP listener, which should respond to requests *)
+      arp_listener;
+      (* send a request for the ARP listener to respond to *)
+      Time.sleep_ns (Duration.of_ms 100) >>= fun () ->
+      V.write inquirer.netif request >>= fun _ ->
+      Time.sleep_ns (Duration.of_ms 100) >>= fun () ->
+      V.disconnect answerer.netif
+    ];
+  )
+
+let requests_not_us () =
+  let (answerer_ip, inquirer_ip) = (first_ip, second_ip) in
+  two_arp () >>= fun (answerer, inquirer) ->
+  A.add_ip answerer.arp answerer_ip >>= fun () ->
+  A.add_ip inquirer.arp inquirer_ip >>= fun () ->
+  let ask ip =
+    let open Arp_packet in
+    encode
+      { operation = Request;
+        source_mac = (V.mac inquirer.netif); target_mac = Macaddr.broadcast;
+        source_ip = inquirer_ip; target_ip = ip }
+  in
+  let requests = List.map ask [ inquirer_ip; Ipaddr.V4.any;
+                                Ipaddr.V4.of_string_exn "255.255.255.255" ] in
+  let make_requests = Lwt_list.iter_s (fun b -> V.write inquirer.netif b >|= fun _ -> ()) requests in
+  let disconnect_listeners () =
+    Lwt_list.iter_s (V.disconnect) [answerer.netif; inquirer.netif]
+  in
+  Lwt.join [
+    (V.listen answerer.netif (start_arp_listener answerer ()) >|= fun _ -> ());
+    (V.listen inquirer.netif (fail_on_receipt inquirer.netif) >|= fun _ -> ());
+    make_requests >>= fun _ ->
+    Time.sleep_ns (Duration.of_ms 100) >>=
+    disconnect_listeners
+  ]
+
+let nonsense_requests () =
+  let (answerer_ip, inquirer_ip) = (first_ip, second_ip) in
+  three_arp () >>= fun (answerer, inquirer, checker) ->
+  A.set_ips answerer.arp [ answerer_ip ] >>= fun () ->
+  let request number =
+    let open Arp_packet in
+    let buf = encode
+        { operation = Request;
+	  source_mac = (V.mac inquirer.netif);
+	  target_mac = Macaddr.broadcast;
+	  source_ip = inquirer_ip;
+	  target_ip = answerer_ip } in
+    Cstruct.BE.set_uint16 buf 6 number;
+    let eth_header = { Ethif_packet.source = (V.mac inquirer.netif);
+                       destination = Macaddr.broadcast;
+                       ethertype = Ethif_wire.ARP;
+                       } in
+    Cstruct.concat [ Ethif_packet.Marshal.make_cstruct eth_header; buf ]
+  in
+  let requests = List.map request [0; 3; -1; 255; 256; 257; 65536] in
+  let make_requests = Lwt_list.iter_s (fun l -> V.write inquirer.netif l >|= fun _ -> ()) requests in
+  let expected_probe = Arp_packet.{ operation = Request;
+                                    source_mac = V.mac answerer.netif;
+                                    source_ip = answerer_ip;
+                                    target_mac = Macaddr.broadcast;
+                                    target_ip = inquirer_ip; }
+  in
+  Lwt.async (fun () -> V.listen answerer.netif (start_arp_listener answerer ()));
+  timeout ~time:1000 (
+    Lwt.join [
+      (V.listen inquirer.netif (fail_on_receipt inquirer.netif) >|= fun _ -> ());
+      make_requests >>= fun () ->
+      V.disconnect inquirer.netif >>= fun () ->
+      (* not sufficient to just check to see whether we've replied; it's equally
+         possible that we erroneously make a cache entry.  Make sure querying
+         inquirer_ip results in an outgoing request. *)
+      not_in_cache ~listen:checker.netif expected_probe answerer.arp inquirer_ip
+    ] )
+
+let packet () =
+  let first_mac  = Macaddr.of_string_exn "10:9a:dd:01:23:45" in
+  let second_mac = Macaddr.of_string_exn "00:16:3e:ab:cd:ef" in
+  let example_request =
+    Arp_packet.{ operation = Request;
+                 source_mac = first_mac;
+                 target_mac = second_mac;
+                 source_ip = first_ip;
+                 target_ip = second_ip;
+               }
+  in
+  let marshalled = Arp_packet.encode example_request in
+  match Arp_packet.decode marshalled with
+  | Error _ -> Alcotest.fail "couldn't unmarshal something we made ourselves"
+  | Ok unmarshalled ->
+    Alcotest.(check packet) "serialize/deserialize" example_request unmarshalled;
+    Lwt.return_unit
+
+let suite =
+  [
+    "conversions neither lose nor gain information", `Quick, packet;
+    "nonsense requests are ignored", `Quick, nonsense_requests;
+    "requests are responded to", `Quick, requests_are_responded_to;
+    "irrelevant requests are ignored", `Quick, requests_not_us;
+    "set_ip sets ip, sends GARP", `Quick, set_ip_sends_garp;
+    "add_ip, get_ip and remove_ip as advertised", `Quick, add_get_remove_ips;
+    "GARPs are heard and not cached", `Quick, input_single_garp;
+    "unsolicited unicast replies are heard and not cached", `Quick, input_single_unicast;
+    "solicited unicast replies resolve pending threads", `Quick, input_resolves_wait;
+    "entries are replaced with new information", `Quick, input_replaces_old;
+    "unreachable IPs time out", `Quick, unreachable_times_out;
+    "queries are tried repeatedly before timing out", `Quick, query_retries;
+    "entries expire", `Quick, entries_expire;
+  ]
+
+let run test () =
+  Lwt_main.run (test ())
+
+let () =
+  (* enable logging to stdout for all modules *)
+  Logs.set_reporter (Logs_fmt.reporter ());
+  Logs.set_level ~all:true (Some Logs.Debug);
+  let suite =
+    [ "arp", List.map (fun (d, s, f) -> d, s, run f) suite ]
+  in
+  Alcotest.run "arp" suite

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -198,7 +198,7 @@ module Handling = struct
   let m =
     let module M = struct
       type t = Macaddr.t
-      let pp ppf m = Format.pp_print_string ppf (Macaddr.to_string m)
+      let pp = Macaddr.pp
       let equal a b = Macaddr.compare a b = 0
     end in
     (module M : Alcotest.TESTABLE with type t = M.t)
@@ -229,7 +229,7 @@ module Handling = struct
     in
     Alcotest.(check bool "create has good GARP" true
                 (Cstruct.equal (Arp_packet.encode (garp_of ipaddr mac)) (fst garp))) ;
-    Alcotest.(check i "ip is sensible" ipaddr (Arp_handler.ip t)) ;
+    Alcotest.(check (list i) "ip is sensible" [ipaddr] (Arp_handler.ips t)) ;
     Alcotest.(check (option m) "own entry is in cache"
                 (Some mac) (Arp_handler.in_cache t ipaddr)) ;
     Alcotest.(check (option m) "any is not in cache" None
@@ -242,7 +242,7 @@ module Handling = struct
     and ipaddr = gen_ip ()
     in
     let t, _garp = Arp_handler.create ~ipaddr mac in
-    Alcotest.(check i "ip is sensible" ipaddr (Arp_handler.ip t)) ;
+    Alcotest.(check (list i) "ip is sensible" [ipaddr] (Arp_handler.ips t)) ;
     Alcotest.(check (option m) "own entry is in cache"
                 (Some mac) (Arp_handler.in_cache t ipaddr)) ;
     let t = Arp_handler.remove t ipaddr in
@@ -254,7 +254,7 @@ module Handling = struct
     and ipaddr = gen_ip ()
     in
     let t, _garp = Arp_handler.create ~ipaddr mac in
-    Alcotest.(check i "ip is sensible" ipaddr (Arp_handler.ip t)) ;
+    Alcotest.(check (list i) "ip is sensible" [ipaddr] (Arp_handler.ips t)) ;
     Alcotest.(check (option m) "own entry is in cache"
                 (Some mac) (Arp_handler.in_cache t ipaddr)) ;
     let t = Arp_handler.remove t Ipaddr.V4.any in
@@ -266,7 +266,7 @@ module Handling = struct
     and ipaddr = gen_ip ()
     in
     let t, _garp = Arp_handler.create ~ipaddr mac in
-    Alcotest.(check i "ip is sensible" ipaddr (Arp_handler.ip t)) ;
+    Alcotest.(check (list i) "ip is sensible" [ipaddr] (Arp_handler.ips t)) ;
     Alcotest.(check (option m) "own entry is in cache"
                 (Some mac) (Arp_handler.in_cache t ipaddr)) ;
     let t, _, _ = Arp_handler.alias t ipaddr in
@@ -373,7 +373,7 @@ module Handling = struct
     let module M = struct
       type t = Cstruct.t * Macaddr.t
       let pp ppf (cs, mac) =
-        Format.fprintf ppf "out: %d to %s" (Cstruct.len cs) (Macaddr.to_string mac)
+        Format.fprintf ppf "out: %d to %a" (Cstruct.len cs) Macaddr.pp mac
       let equal (acs, amac) (bcs, bmac) =
         Cstruct.equal acs bcs && Macaddr.compare amac bmac = 0
     end in
@@ -383,10 +383,10 @@ module Handling = struct
     let module M = struct
       type t = int list Arp_handler.qres
       let pp ppf = function
-        | Arp_handler.Mac mac -> Format.fprintf ppf "ok %s" (Macaddr.to_string mac)
+        | Arp_handler.Mac mac -> Format.fprintf ppf "ok %a" Macaddr.pp mac
         | Arp_handler.RequestWait ((cs, mac), xs) ->
-          Format.fprintf ppf "requestwait %d to %s, wait %s"
-            (Cstruct.len cs) (Macaddr.to_string mac)
+          Format.fprintf ppf "requestwait %d to %a, wait %s"
+            (Cstruct.len cs) Macaddr.pp mac
             (String.concat ", " (List.map string_of_int xs))
         | Arp_handler.Wait xs ->
           Format.fprintf ppf "wait %s"


### PR DESCRIPTION
    move mirage-tcpip/tests/test_arpv4.ml in this repository
    
    behavioural change is that unsolicited ARP frames are dropped in this
    implementation in contrast to mirage-tcpip's one.
    
    minor changes:
    - provide Arp_handler.ips : t -> Ipaddr.V4.t list (for testing etc.)
    - remove unused Clock : Mirage_clock.MCLOCK from arp-mirage functor
    - provide Arp_packet.equal

~~also stumbled upon an exception in mirage-vnetif, pinning a branch thereof which does not raise (not sure what the actual problem is, already spent 3 hours in debugging this)~~