### PR TITLE
Rename ethif to ethernet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ script: bash -ex .travis-opam.sh
 sudo: required
 env:
   global:
-    - PINS="arp.1.0.0:. arp-mirage.1.0.0:."
+    - PINS="arp:. arp-mirage:."
     - TESTS=true
+    - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git#layering"
   matrix:
     - OCAML_VERSION=4.04 PACKAGE="arp-mirage"
     - OCAML_VERSION=4.05 PACKAGE="arp"

--- a/arp-mirage.opam
+++ b/arp-mirage.opam
@@ -9,15 +9,15 @@ license: "ISC"
 synopsis: "Address Resolution Protocol for MirageOS"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "mirage-protocols-lwt"
   "mirage-time-lwt"
   "mirage-protocols-lwt" {>= "2.0.0"}
-  "ethernet" {>= "2.0.0"}
   "lwt"
   "duration"
   "arp" {>= "2.0.0"}
+  "mirage-profile" {>= "0.5"}
   "logs"
   "cstruct" {>= "2.2.0"}
+  "ethernet" {with-test & >= "2.0.0"}
   "fmt" {with-test}
   "mirage-vnetif" {with-test}
   "alcotest" {with-test}

--- a/arp-mirage.opam
+++ b/arp-mirage.opam
@@ -11,11 +11,11 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "mirage-protocols-lwt"
   "mirage-time-lwt"
-  "mirage-protocols-lwt"
-  "ethernet"
+  "mirage-protocols-lwt" {>= "2.0.0"}
+  "ethernet" {>= "2.0.0"}
   "lwt"
   "duration"
-  "arp" {>= "1.0.0"}
+  "arp" {>= "2.0.0"}
   "logs"
   "cstruct" {>= "2.2.0"}
   "fmt" {with-test}

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -3,37 +3,34 @@
 let count2 = ref 0
 
 module Test (R : Mirage_random.C) = struct
-let hdr =
-  let buf = Cstruct.create 6 in
+let hdr buf =
   Cstruct.BE.set_uint16 buf 0 1 ;
   Cstruct.BE.set_uint16 buf 2 0x0800 ;
   Cstruct.set_uint8 buf 4 6 ;
-  Cstruct.set_uint8 buf 5 4 ;
-  buf
+  Cstruct.set_uint8 buf 5 4
 
 let gen_int () =
   let buf = R.generate 1 in
   Cstruct.get_uint8 buf 0
 
-let gen_op () =
+let gen_op buf off =
   let op = gen_int () in
-  let buf = Cstruct.create 2 in
   let op = 1 + op mod 2 in
-  Cstruct.BE.set_uint16 buf 0 op ;
-  buf
+  Cstruct.BE.set_uint16 buf off op
 
-let gen_arp () =
-  let addresses = R.generate 20
-  and opb = gen_op ()
-  in
-  Cstruct.concat [ hdr ; opb ; addresses ]
+let gen_arp buf =
+  hdr buf ;
+  gen_op buf 6 ;
+  let addresses = R.generate 20 in
+  Cstruct.blit addresses 0 buf 8 20 ;
+  28
 
-let gen_req () =
-  let addresses = R.generate 20
-  and opb = Cstruct.create 2
-  in
-  Cstruct.BE.set_uint16 opb 0 1 ;
-  Cstruct.concat [ hdr ; opb ; addresses ]
+let gen_req buf =
+  hdr buf ;
+  Cstruct.BE.set_uint16 buf 6 1 ;
+  let addresses = R.generate 20 in
+  Cstruct.blit addresses 0 buf 8 20 ;
+  28
 
 let gen_ip () =
   let last = R.generate 1 in
@@ -43,31 +40,28 @@ let gen_ip () =
 let ip = Ipaddr.V4.of_string_exn "10.0.0.0"
 let mac = Macaddr.of_string_exn "00:de:ad:be:ef:00"
 
-let gen_rep () =
-  let omac = R.generate 6
-  and oip = gen_ip ()
-  and opb = Cstruct.create 2
-  in
-  Cstruct.BE.set_uint16 opb 0 2 ;
-  let add = String.concat "" [
-      Ipaddr.V4.to_bytes oip ;
-      Macaddr.to_bytes mac ;
-      Ipaddr.V4.to_bytes ip
-    ] in
-  Cstruct.concat [ hdr ; opb ; omac ; Cstruct.of_string add ]
+let gen_rep buf =
+  hdr buf ;
+  Cstruct.BE.set_uint16 buf 6 2 ;
+  let omac = R.generate 6 in
+  Cstruct.blit omac 0 buf 8 6 ;
+  let oip = gen_ip () in
+  Cstruct.blit_from_string (Ipaddr.V4.to_bytes oip) 0 buf 14 4 ;
+  Cstruct.blit_from_string (Macaddr.to_bytes mac) 0 buf 18 6 ;
+  Cstruct.blit_from_string (Ipaddr.V4.to_bytes ip) 0 buf 24 4 ;
+  28
 
 let other_ip = Ipaddr.V4.of_string_exn "10.0.0.1"
 let other_mac = Macaddr.of_string_exn "00:de:ad:be:ef:01"
 
-let myreq =
-  let req = Cstruct.create 2 in
-  Cstruct.BE.set_uint16 req 0 1 ;
-  let addresses = String.concat "" [
-      Macaddr.to_bytes other_mac; Ipaddr.V4.to_bytes other_ip ;
-      Macaddr.to_bytes mac; Ipaddr.V4.to_bytes ip
-    ]
-  in
-  Cstruct.concat [ hdr ; req ; Cstruct.of_string addresses ]
+let myreq buf =
+  hdr buf ;
+  Cstruct.BE.set_uint16 buf 6 1 ;
+  Cstruct.blit_from_string (Macaddr.to_bytes other_mac) 0 buf 8 6 ;
+  Cstruct.blit_from_string (Ipaddr.V4.to_bytes other_ip) 0 buf 14 4 ;
+  Cstruct.blit_from_string (Macaddr.to_bytes mac) 0 buf 18 6 ;
+  Cstruct.blit_from_string (Ipaddr.V4.to_bytes ip) 0 buf 24 4 ;
+  28
 
 open Lwt.Infix
 
@@ -77,12 +71,16 @@ module E = Ethernet.Make(V)
 module A = Arp.Make(E)(OS.Time)
 
 let c = ref 0
-let gen arp () =
+let gen arp buf =
   c := !c mod 100 ;
   match !c with
-  | x when x >= 00 && x < 10 -> R.generate (gen_int ())
-  | x when x >= 10 && x < 20 -> gen_req ()
-  | x when x >= 20 && x < 50 -> myreq
+  | x when x >= 00 && x < 10 ->
+    let len = gen_int () mod 28 in
+    let r = R.generate len in
+    Cstruct.blit r 0 buf 0 len ;
+    len
+  | x when x >= 10 && x < 20 -> gen_req buf
+  | x when x >= 20 && x < 50 -> myreq buf
   | x when x >= 50 && x < 80 ->
     if x mod 2 = 0 then
       (let rand = gen_int () in
@@ -90,8 +88,8 @@ let gen arp () =
          let ip = gen_ip () in
          Lwt.async (fun () -> A.query arp ip)
        done) ;
-    gen_rep ()
-  | x when x >= 80 && x < 100 -> gen_arp ()
+    gen_rep buf
+  | x when x >= 80 && x < 100 -> gen_arp buf
   | _ -> invalid_arg "bla"
 
 let rec query arp () =
@@ -116,7 +114,7 @@ let get_arp ?(backend = B.create ~use_async_readers:true
   Lwt.return { backend; netif; ethif; arp }
 
 let rec send netif gen () =
-  V.write netif (gen ()) >>= function
+  V.write netif ~size:Arp_packet.size gen >>= function
   | Ok _ -> send netif gen ()
   | Error _ -> Lwt.return_unit
 
@@ -128,7 +126,10 @@ let runit () =
   let count = ref 0 in
   Lwt.pick [
     (V.listen stack.netif (fun b -> incr count ; A.input stack.arp b) >|= fun _ -> ());
-    send other.netif (fun () -> R.generate 28) () ;
+    send other.netif (fun b ->
+        let res = R.generate 28 in
+        Cstruct.blit res 0 b 0 28 ;
+        28) () ;
     OS.Time.sleep_ns (Duration.of_sec 5)
   ] >>= fun () ->
   Printf.printf "%d random input\n%!" !count ;

--- a/mirage/arp.mli
+++ b/mirage/arp.mli
@@ -15,8 +15,8 @@
  *
  *)
 
-module Make (Ethif : Mirage_protocols_lwt.ETHIF) (Time : Mirage_time_lwt.S) : sig
+module Make (Ethernet : Mirage_protocols_lwt.ETHERNET) (Time : Mirage_time_lwt.S) : sig
   include Mirage_protocols_lwt.ARP
 
-  val connect : Ethif.t -> t Lwt.t
+  val connect : Ethernet.t -> t Lwt.t
 end

--- a/mirage/dune
+++ b/mirage/dune
@@ -2,4 +2,4 @@
  (name arp_mirage)
  (public_name arp-mirage)
  (wrapped false)
- (libraries arp mirage-protocols mirage-protocols-lwt mirage-time-lwt lwt logs ethernet duration))
+ (libraries arp mirage-protocols mirage-protocols-lwt mirage-time-lwt lwt logs duration mirage-profile))

--- a/src/arp_handler.ml
+++ b/src/arp_handler.ml
@@ -68,9 +68,7 @@ let alias t ip =
     (fun pp -> pp "Sending gratuitous ARP for %a (%a)"
         Ipaddr.V4.pp ip Macaddr.pp t.mac) ;
   (*BISECT-IGNORE-END*)
-  { t with cache },
-  (Arp_packet.encode garp, Macaddr.broadcast),
-  pending t ip
+  { t with cache }, (garp, Macaddr.broadcast), pending t ip
 
 let create ?(timeout = 800) ?(retries = 5)
     ?(logsrc = Logs.Src.create "arp" ~doc:"ARP handler")
@@ -112,7 +110,7 @@ let request t ip =
     target_mac = target ; target_ip = ip
   }
   in
-  Arp_packet.encode request, target
+  request, target
 
 let reply arp m =
   let reply = {
@@ -120,7 +118,7 @@ let reply arp m =
     source_mac = m ; source_ip = arp.Arp_packet.target_ip ;
     target_mac = arp.Arp_packet.source_mac ; target_ip = arp.Arp_packet.source_ip ;
   } in
-  Arp_packet.encode reply, arp.Arp_packet.source_mac
+  reply, arp.Arp_packet.source_mac
 
 let tick t =
   let epoch = t.epoch in
@@ -232,7 +230,7 @@ let input t buf =
 type 'a qres =
   | Mac of Macaddr.t
   | Wait of 'a
-  | RequestWait of (Cstruct.t * Macaddr.t) * 'a
+  | RequestWait of (Arp_packet.t * Macaddr.t) * 'a
 
 let query t ip a =
   match M.find ip t.cache with

--- a/src/arp_handler.mli
+++ b/src/arp_handler.mli
@@ -55,7 +55,7 @@ type 'a t
     @raise Invalid_argument is [timeout] is 0 or negative or [retries] is
     negative.  *)
 val create : ?timeout:int -> ?retries:int -> ?logsrc:Logs.src ->
-  ?ipaddr:Ipaddr.V4.t -> Macaddr.t -> 'a t * (Cstruct.t * Macaddr.t) option
+  ?ipaddr:Ipaddr.V4.t -> Macaddr.t -> 'a t * (Arp_packet.t * Macaddr.t) option
 
 (** [pp ppf t] prints the ARP handler [t] on [ppf] by iterating over all cache
     entries. *)
@@ -83,7 +83,7 @@ val static : 'a t -> Ipaddr.V4.t -> Macaddr.t -> 'a t * 'a option
 (** [alias t ip] is [t', out, as], where [t'] is [t] extended by a static ARP
     entry for [ip].  This entry will be used to answer further ARP requests.
     [out] is a gratuitous ARP frame.  The tasks waiting for [ip] are [as]. *)
-val alias : 'a t -> Ipaddr.V4.t -> 'a t * (Cstruct.t * Macaddr.t) * 'a option
+val alias : 'a t -> Ipaddr.V4.t -> 'a t * (Arp_packet.t * Macaddr.t) * 'a option
 
 (** [remove t ip] is [t'], where [ip] is no longer in the cache. *)
 val remove : 'a t -> Ipaddr.V4.t -> 'a t
@@ -93,14 +93,14 @@ val remove : 'a t -> Ipaddr.V4.t -> 'a t
 (** [tick t] is [t', requests, timeouts], which advances the state [t] into
     [t'].  Possibly retransmissions of ARP requests need to be done, provided in
     the [requests] list.  Timed out queries are in the [timeouts] list. *)
-val tick : 'a t -> 'a t * (Cstruct.t * Macaddr.t) list * 'a list
+val tick : 'a t -> 'a t * (Arp_packet.t * Macaddr.t) list * 'a list
 
 (** [input t buf] is [t', reply, w], which handles the input buffer [buf] in the
     state [t].  The state is transformed into [t'].  If it was an ARP request
     for one of our IPv4 addresses, an ARP reply should be send out [reply].  If
     the input was an awaited ARP reply, some elements [w] can be informed.  *)
 val input : 'a t -> Cstruct.t ->
-  ('a t * (Cstruct.t * Macaddr.t) option * (Macaddr.t * 'a) option)
+  ('a t * (Arp_packet.t * Macaddr.t) option * (Macaddr.t * 'a) option)
 
 (** The type returned by query, either a [Mac] and a mac address, or [Wait] for
     a reply, or [RequestWait], consisting of an ARP request to be send on the wire,
@@ -108,7 +108,7 @@ val input : 'a t -> Cstruct.t ->
 type 'a qres =
   | Mac of Macaddr.t
   | Wait of 'a
-  | RequestWait of (Cstruct.t * Macaddr.t) * 'a
+  | RequestWait of (Arp_packet.t * Macaddr.t) * 'a
 
 (** [query t ip merge] is [t', qres], which looks for the [ip] in the cache.  If
     it is found, its value is [Mac mac].  If the [ip] is not in the cache,

--- a/src/arp_packet.ml
+++ b/src/arp_packet.ml
@@ -61,7 +61,7 @@ let ipv4_ethertype = 0x0800
 and ipv4_size = 4
 and ether_htype = 1
 and ether_size = 6
-and arp_frame_size = 28
+and size = 28
 
 let guard p e = if p then Ok () else Error e
 
@@ -70,7 +70,7 @@ let (>>=) x f = match x with
   | Error e -> Error e
 
 let decode buf =
-  let check_len buf = Cstruct.len buf >= arp_frame_size in
+  let check_len buf = Cstruct.len buf >= size in
   let check_hdr buf =
     Cstruct.BE.get_uint16 buf 0 = ether_htype &&
     Cstruct.BE.get_uint16 buf 2 = ipv4_ethertype &&
@@ -112,6 +112,6 @@ let encode_into t buf =
   [@@inline]
 
 let encode t =
-  let buf = Cstruct.create_unsafe arp_frame_size in
+  let buf = Cstruct.create_unsafe size in
   encode_into t buf;
   buf

--- a/src/arp_packet.mli
+++ b/src/arp_packet.mli
@@ -21,6 +21,9 @@ type t = {
   target_ip : Ipaddr.V4.t;
 }
 
+(** [size] is the size of an ARP frame. *)
+val size : int
+
 (** [pp ppf t] prints the frame [t] on [ppf]. *)
 val pp : Format.formatter -> t -> unit
 


### PR DESCRIPTION
this is on top of #13 and should be merged thereafter, but before a 2.0 release. see https://github.com/mirage/mirage-protocols/pull/16