### PR TITLE
Dune is a build dependency

### DIFF
--- a/arp-mirage.opam
+++ b/arp-mirage.opam
@@ -9,6 +9,7 @@ license: "ISC"
 synopsis: "Address Resolution Protocol for MirageOS"
 depends: [
   "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
   "mirage-time-lwt"
   "mirage-protocols-lwt" {>= "2.0.0"}
   "lwt"

--- a/arp.opam
+++ b/arp.opam
@@ -9,6 +9,7 @@ license: "ISC"
 
 depends: [
   "ocaml" {>= "4.04.2"}
+  "dune" {build & >= "1.0"}
   "cstruct" {>= "2.2.0"}
   "ipaddr" {>= "3.0.0"}
   "macaddr"


### PR DESCRIPTION
Useful for mirage/mirage#969
It should be nice to also update opam-repository accordingly 